### PR TITLE
Hide bookmarks tab when not logged in

### DIFF
--- a/src/components/navigation/feed-navigation.tsx
+++ b/src/components/navigation/feed-navigation.tsx
@@ -5,7 +5,7 @@ import { getTokenClaims } from "@/lib/auth/get-token-claims";
 export const FeedNavigation = () => {
   const token = getAppToken();
   const claims = getTokenClaims(token);
-  const isLoggedIn = !!claims && claims.metadata?.isAnonymous === false;
+  const isLoggedIn = !claims || (!!claims && claims.metadata?.isAnonymous === false);
 
   return (
     <div className="p-4 pb-0 font-[family-name:var(--title-font)] border-b border-border w-full max-w-3xl">

--- a/src/components/navigation/feed-navigation.tsx
+++ b/src/components/navigation/feed-navigation.tsx
@@ -1,6 +1,12 @@
 import { SlideNav } from "@/components/ui/slide-tabs";
+import { getAppToken } from "@/lib/auth/get-app-token";
+import { getTokenClaims } from "@/lib/auth/get-token-claims";
 
 export const FeedNavigation = () => {
+  const token = getAppToken();
+  const claims = getTokenClaims(token);
+  const isLoggedIn = !!claims && claims.metadata?.isAnonymous === false;
+
   return (
     <div className="p-4 pb-0 font-[family-name:var(--title-font)] border-b border-border w-full max-w-3xl">
       <SlideNav
@@ -16,10 +22,11 @@ export const FeedNavigation = () => {
           {
             href: "/bookmarks",
             label: "Bookmarks",
+            isVisible: isLoggedIn,
           },
         ]}
         className="w-fit"
       />
     </div>
   );
-}; 
+};


### PR DESCRIPTION
## Summary
- check cookies on the server to determine if the user is logged in
- hide the `Bookmarks` tab in the feed navigation for guests

## Testing
- `bun x @biomejs/biome lint --write --unsafe ./src` *(fails: ConnectionRefused)*