### PR TITLE
Improve wallet reconnection UX

### DIFF
--- a/src/components/auth/onboarding-modal.tsx
+++ b/src/components/auth/onboarding-modal.tsx
@@ -5,6 +5,7 @@ import { account as accountMetadataBuilder, image, MetadataAttribute } from "@le
 import { useState, useEffect, useCallback, useRef } from "react";
 import { toast } from "sonner";
 import { useAccount, useSignMessage, useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { Button } from "../ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import { Input } from "../ui/input";
@@ -39,6 +40,7 @@ export function OnboardingModal({ open, onOpenChange, onSuccess }: OnboardingMod
   const router = useRouter();
   const { signMessageAsync } = useSignMessage();
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
 
   const validateUsername = useCallback(async (name: string) => {
     if (!name || name.length <= 2) {
@@ -157,6 +159,12 @@ export function OnboardingModal({ open, onOpenChange, onSuccess }: OnboardingMod
   const handleFinalSubmit = async (profileData: ProfileSetupData) => {
     if (!username || !walletAddress) {
       toast.error("Username is missing.");
+      return;
+    }
+
+    if (!walletClient) {
+      reconnectWallet();
+      toast.error("Please connect your wallet first");
       return;
     }
 

--- a/src/components/blog/blog-create-modal.tsx
+++ b/src/components/blog/blog-create-modal.tsx
@@ -13,6 +13,7 @@ import { Label } from "../ui/label";
 import { Textarea } from "../ui/textarea";
 import { handleOperationWith } from "@lens-protocol/client/viem";
 import { useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { getLensClient } from "@/lib/lens/client";
 import { Plus } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -45,6 +46,7 @@ export function CreateBlogModal({ open, onOpenChange, onSuccess }: CreateGroupMo
   const [description, setDescription] = useState("");
   const [loading, setLoading] = useState(false);
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   const { data: user } = useAuthenticatedUser();
 
   const slugIsValid = slug === "" || isValidSlug(slug);
@@ -69,6 +71,12 @@ export function CreateBlogModal({ open, onOpenChange, onSuccess }: CreateGroupMo
 
     if (!user || !user.address) {
       toast.error("Please login to create a blog");
+      return;
+    }
+
+    if (!walletClient) {
+      reconnectWallet();
+      toast.error("Please connect your wallet");
       return;
     }
 

--- a/src/components/comment/comment-reply-area.tsx
+++ b/src/components/comment/comment-reply-area.tsx
@@ -11,6 +11,7 @@ import { textOnly } from "@lens-protocol/metadata";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useAccount, useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { UserAvatar } from "../user/user-avatar";
 import { UserUsername } from "../user/user-handle";
 import { UserName } from "../user/user-name";
@@ -39,11 +40,18 @@ export const CommentReplyArea = ({
   const [content, setContent] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   const { isConnected: isWalletConnected, status: walletClientStatus } = useAccount();
   const { data: authenticatedUser, loading: isAuthenticatedUserLoading } = useAuthenticatedUser();
 
   const handleSubmit = async () => {
     if (!content.trim() || isSubmitting) return;
+
+    if (!walletClient) {
+      reconnectWallet();
+      toast.error("Please connect your wallet");
+      return;
+    }
 
     setIsSubmitting(true);
     const pendingToast = toast.loading("Publishing comment...");

--- a/src/components/post/post-collect-dialog.tsx
+++ b/src/components/post/post-collect-dialog.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Info, Calendar, Users } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { useState } from "react";
 import { getLensClient } from "@/lib/lens/client";
 import { toast } from "sonner";
@@ -65,6 +66,7 @@ interface PostCollectProps {
 
 export const PostCollect = ({ post, isOpen, onOpenChange }: PostCollectProps) => {
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   const [isCollecting, setIsCollecting] = useState(false);
 
   const collectAction = post.actions.find((action) => action.__typename === "SimpleCollectAction") as
@@ -94,7 +96,13 @@ export const PostCollect = ({ post, isOpen, onOpenChange }: PostCollectProps) =>
   const endsAt = collectAction?.endsAt ? new Date(collectAction.endsAt) : null;
 
   const handleCollect = async () => {
-    if (!walletClient || !canCollect) return;
+    if (!walletClient || !canCollect) {
+      if (!walletClient) {
+        reconnectWallet();
+        toast.error("Please connect your wallet");
+      }
+      return;
+    }
 
     try {
       setIsCollecting(true);

--- a/src/components/post/post-floating-actions-bar.tsx
+++ b/src/components/post/post-floating-actions-bar.tsx
@@ -4,7 +4,6 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { useScroll } from "@/hooks/use-scroll";
 import { Account, AnyPost, Post } from "@lens-protocol/client";
 import { motion } from "motion/react";
-import { useWalletClient } from "wagmi";
 import { ActionButton } from "./post-action-button";
 import React from "react";
 import { useActionBar } from "@/contexts/action-bar-context";

--- a/src/components/post/post-menu.tsx
+++ b/src/components/post/post-menu.tsx
@@ -8,6 +8,7 @@ import { Bookmark, Link, MoreHorizontal, Trash2, Pencil } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { ActionButton, type DropdownItem } from "./post-action-button";
 import { usePostActions } from "@/hooks/use-post-actions";
 import { getLensClient } from "@/lib/lens/client";
@@ -29,6 +30,7 @@ import { ConfirmButton } from "@/components/ui/confirm-button";
 export const PostMenu = ({ post }: { post: Post }) => {
   const { handleBookmark, stats, operations, isLoggedIn } = usePostActions(post);
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   const router = useRouter();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -59,7 +61,7 @@ export const PostMenu = ({ post }: { post: Post }) => {
         return;
       }
 
-      let contentJson;
+      let contentJson: any;
       try {
         contentJson = JSON.parse(contentJsonAttribute.value as string);
       } catch (e) {
@@ -110,6 +112,12 @@ export const PostMenu = ({ post }: { post: Post }) => {
 
       if (!lens.isSessionClient()) {
         toast.error("You need to be logged in to delete a post");
+        return;
+      }
+
+      if (!walletClient) {
+        reconnectWallet();
+        toast.error("Please connect your wallet first");
         return;
       }
 

--- a/src/components/publish/publish-dialog.tsx
+++ b/src/components/publish/publish-dialog.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import {
   PenIcon,
   ShoppingBag as ShoppingBagIcon,
@@ -66,6 +67,7 @@ export const PublishMenu = ({ documentId }: PublishMenuProps) => {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
 
   const formToDraft = (values: CombinedFormValues, currentDraft: Draft | null, blogState: any): Partial<Draft> => {
     const selectedBlogAddress = values.distribution?.selectedBlogAddress || "";
@@ -259,6 +261,12 @@ export const PublishMenu = ({ documentId }: PublishMenuProps) => {
   const onSubmit = async (data: CombinedFormValues) => {
     const draft = getDraft();
     if (!draft) return;
+
+    if (!walletClient) {
+      reconnectWallet();
+      toast.error("Please connect your wallet");
+      return;
+    }
 
     const finalDraft: Draft = {
       ...draft,

--- a/src/components/settings/settings-app.tsx
+++ b/src/components/settings/settings-app.tsx
@@ -13,6 +13,7 @@ import { getLensClient } from "@/lib/lens/client";
 import { enableSignless, fetchMeDetails, removeSignless } from "@lens-protocol/client/actions";
 import { handleOperationWith } from "@lens-protocol/client/viem";
 import { useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
 
@@ -31,6 +32,7 @@ export function ApplicationSettings({ initialSettings = {}, initialEmail }: Appl
   const [isDirty, setIsDirty] = useState(false);
   const [isSignless, setIsSignless] = useState(false);
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
 
   useEffect(() => {
     const fetchSignlessStatus = async () => {
@@ -47,7 +49,13 @@ export function ApplicationSettings({ initialSettings = {}, initialEmail }: Appl
 
   const handleSignlessChange = async (checked: boolean) => {
     const client = await getLensClient();
-    if (!client.isSessionClient() || !walletClient) {
+    if (!client.isSessionClient()) {
+      toast.error("Please connect your wallet first");
+      return;
+    }
+
+    if (!walletClient) {
+      reconnectWallet();
       toast.error("Please connect your wallet first");
       return;
     }

--- a/src/components/settings/settings-blog.tsx
+++ b/src/components/settings/settings-blog.tsx
@@ -12,6 +12,7 @@ import { TextareaAutosize } from "../ui/textarea";
 import { BlogData, BlogMetadata } from "@/lib/settings/get-blog-data";
 import { useBlogSettings } from "@/hooks/use-blog-settings";
 import { useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import Link from "next/link";
 import { ArrowLeftIcon, ExternalLink, MailIcon } from "lucide-react";
 import { isValidTheme, ThemeType, themeNames, themeDescriptions, defaultThemeName } from "@/styles/themes";
@@ -119,6 +120,7 @@ interface ImageState {
 export function BlogSettings({ initialSettings, isUserBlog = false, userHandle }: BlogSettingsProps) {
   const { settings, saveSettings } = useBlogSettings(initialSettings);
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   const [formState, setFormState] = useState<FormState>({
     title: settings?.title || "",
     about: settings?.about || "",
@@ -293,6 +295,7 @@ export function BlogSettings({ initialSettings, isUserBlog = false, userHandle }
         }
 
         if (!walletClient) {
+          reconnectWallet();
           toast.error("Please connect your wallet", { id: chainToastId });
           return;
         }
@@ -601,7 +604,10 @@ export function BlogSettings({ initialSettings, isUserBlog = false, userHandle }
                 <div className="bg-background px-3 py-1.5 flex items-center gap-2">
                   {/* Navigation Buttons */}
                   <div className="flex items-center gap-1">
-                    <button className="text-muted-foreground hover:text-foreground transition-colors w-5 h-5 flex items-center justify-center rounded-full">
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground transition-colors w-5 h-5 flex items-center justify-center rounded-full"
+                    >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         width="14"
@@ -616,7 +622,10 @@ export function BlogSettings({ initialSettings, isUserBlog = false, userHandle }
                         <path d="m15 18-6-6 6-6" />
                       </svg>
                     </button>
-                    <button className="text-muted-foreground hover:text-foreground transition-colors w-5 h-5 flex items-center justify-center rounded-full">
+                    <button
+                      type="button"
+                      className="text-muted-foreground hover:text-foreground transition-colors w-5 h-5 flex items-center justify-center rounded-full"
+                    >
                       <svg
                         xmlns="http://www.w3.org/2000/svg"
                         width="14"
@@ -643,7 +652,10 @@ export function BlogSettings({ initialSettings, isUserBlog = false, userHandle }
                   </div>
 
                   {/* Reload Button */}
-                  <button className="text-muted-foreground hover:text-foreground transition-colors w-5 h-5 flex items-center justify-center rounded-full">
+                  <button
+                    type="button"
+                    className="text-muted-foreground hover:text-foreground transition-colors w-5 h-5 flex items-center justify-center rounded-full"
+                  >
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
                       width="14"

--- a/src/components/settings/settings-profile.tsx
+++ b/src/components/settings/settings-profile.tsx
@@ -18,7 +18,6 @@ import { Account } from "@lens-protocol/client";
 import { Globe } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
-import { useWalletClient } from "wagmi";
 import { ImageCropperUploader } from "../images/image-uploader";
 import { Button } from "../ui/button";
 import { TextareaAutosize } from "../ui/textarea";

--- a/src/components/tip/tip-popover.tsx
+++ b/src/components/tip/tip-popover.tsx
@@ -8,6 +8,7 @@ import { Post, postId, evmAddress, bigDecimal } from "@lens-protocol/client";
 import { executePostAction } from "@lens-protocol/client/actions";
 import { handleOperationWith, signMessageWith } from "@lens-protocol/client/viem";
 import { useWalletClient, useBalance } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { getLensClient } from "@/lib/lens/client";
 import { toast } from "sonner";
 import { useAuthenticatedUser } from "@lens-protocol/react";
@@ -43,6 +44,7 @@ export const TipPopover = ({ children, onCollectClick, post }: TipPopoverProps) 
   const [isTipping, setIsTipping] = useState(false);
   const [open, setOpen] = useState(false);
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   const { data: authenticatedUser } = useAuthenticatedUser();
 
   const currencyAddress = DEFAULT_CURRENCY;
@@ -80,6 +82,7 @@ export const TipPopover = ({ children, onCollectClick, post }: TipPopoverProps) 
     const hasEnoughBalance = tokenBalance ? Number.parseFloat(tokenBalance) >= Number.parseFloat(finalAmount) : false;
 
     if (!walletClient) {
+      reconnectWallet();
       toast.error("Wallet not connected");
       return;
     }

--- a/src/components/token/token-send-page.tsx
+++ b/src/components/token/token-send-page.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { useAccount, useBalance, useWalletClient, usePublicClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { ConnectWalletButton } from "@/components/auth/auth-wallet-button";
 import { ArrowRight, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
@@ -53,6 +54,7 @@ export function TokenSend({ accountAddress, tokenAddress }: TokenSendClientPageP
   const [tokenType, setTokenType] = useState<"native" | "wrapped">("native");
   const { address: walletAddress, isConnected } = useAccount();
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   const publicClient = usePublicClient();
 
   const { data: walletWrappedGhoBalance, isLoading: isWalletWrappedGhoBalanceLoading } = useBalance({
@@ -77,6 +79,7 @@ export function TokenSend({ accountAddress, tokenAddress }: TokenSendClientPageP
 
   const handleSendToken = async () => {
     if (!walletClient || !walletAddress || !recipientAddress || !publicClient) {
+      if (!walletClient) reconnectWallet();
       toast.error("Wallet not connected or recipient address not provided");
       return;
     }

--- a/src/components/token/token-wrap-dialog.tsx
+++ b/src/components/token/token-wrap-dialog.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Info, ArrowDownUp, AlertCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useWalletClient, useBalance } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { useState, useEffect } from "react";
 import { getLensClient } from "@/lib/lens/client";
 import { toast } from "sonner";
@@ -24,6 +25,7 @@ interface TokenWrapProps {
 
 export const TokenWrapDialog = ({ isOpen, onOpenChange, accountAddress }: TokenWrapProps) => {
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   const [isProcessing, setIsProcessing] = useState(false);
   const [amount, setAmount] = useState<string>("");
   const [mode, setMode] = useState<"wrap" | "unwrap">("wrap");
@@ -51,6 +53,7 @@ export const TokenWrapDialog = ({ isOpen, onOpenChange, accountAddress }: TokenW
 
   const handleWrapTokens = async () => {
     if (!walletClient || !amount || Number.parseFloat(amount) <= 0) {
+      if (!walletClient) reconnectWallet();
       toast.error("Please enter a valid amount");
       return;
     }
@@ -93,6 +96,7 @@ export const TokenWrapDialog = ({ isOpen, onOpenChange, accountAddress }: TokenW
 
   const handleUnwrapTokens = async () => {
     if (!walletClient || !amount || Number.parseFloat(amount) <= 0) {
+      if (!walletClient) reconnectWallet();
       toast.error("Please enter a valid amount");
       return;
     }

--- a/src/components/token/token-wrap-page.tsx
+++ b/src/components/token/token-wrap-page.tsx
@@ -4,6 +4,7 @@ import { TokenWrapDialog } from "@/components/token/token-wrap-dialog";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import { useAccount, useBalance, useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { ConnectWalletButton } from "@/components/auth/auth-wallet-button";
 import { ArrowRight, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
@@ -20,6 +21,7 @@ export function TokenWrap({ accountAddress, tokenAddress }: TokenWrapClientPageP
   const [transferAmount, setTransferAmount] = useState<string>("");
   const { address: walletAddress, isConnected } = useAccount();
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   console.log("accountAddress", accountAddress);
   console.log("walletAddress", walletAddress);
 
@@ -45,6 +47,7 @@ export function TokenWrap({ accountAddress, tokenAddress }: TokenWrapClientPageP
 
   const handleTransferToAccount = async () => {
     if (!walletClient || !walletAddress || !accountAddress) {
+      if (!walletClient) reconnectWallet();
       toast.error("Wallet or account not connected");
       return;
     }

--- a/src/components/user/user-follow.tsx
+++ b/src/components/user/user-follow.tsx
@@ -6,6 +6,7 @@ import { Button } from "../ui/button";
 import { follow, unfollow } from "@lens-protocol/client/actions";
 import { handleOperationWith } from "@lens-protocol/client/viem";
 import { useWalletClient } from "wagmi";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { getLensClient } from "@/lib/lens/client";
 import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
@@ -15,13 +16,20 @@ export const UserFollowButton = ({ account, className }: { account: Account; cla
   const [following, setFollowing] = useState(() => !!account.operations?.isFollowedByMe);
   const [isPending, setIsPending] = useState(false);
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
   const router = useRouter();
 
   const toggleFollow = async () => {
     try {
       const lens = await getLensClient();
 
-      if (!lens.isSessionClient() || !walletClient) {
+      if (!lens.isSessionClient()) {
+        toast.error("Please connect your wallet first");
+        return;
+      }
+
+      if (!walletClient) {
+        reconnectWallet();
         toast.error("Please connect your wallet first");
         return;
       }
@@ -40,7 +48,7 @@ export const UserFollowButton = ({ account, className }: { account: Account; cla
 
       setIsPending(true);
 
-      let actionResult;
+      let actionResult: any;
       if (following) {
         actionResult = await unfollow(lens, {
           account: account.address,

--- a/src/components/user/user-menu.tsx
+++ b/src/components/user/user-menu.tsx
@@ -92,6 +92,7 @@ export const UserMenu = ({ session, showDropdown = false }: { session: MeResult 
       </DropdownMenuTrigger>
       <DropdownMenuPortal>
         <DropdownMenuContent align="end" className="w-48">
+
           {session && (
             <>
               <AnimatedMenuItem href="/featured" icon={HomeIcon}>
@@ -114,6 +115,12 @@ export const UserMenu = ({ session, showDropdown = false }: { session: MeResult 
           >
             {session ? "Switch Profile" : "Select Profile"}
           </AnimatedMenuItem>
+
+          {!isWalletConnected && (
+            <AnimatedMenuItem icon={Wallet} onClick={reconnectWallet}>
+              Reconnect Wallet
+            </AnimatedMenuItem>
+          )}
 
           {session && (
             <>
@@ -147,14 +154,9 @@ export const UserMenu = ({ session, showDropdown = false }: { session: MeResult 
             </AnimatedMenuItem>
           )}
 
-          {!isWalletConnected && (
-            <AnimatedMenuItem icon={Wallet} onClick={reconnectWallet}>
-              Reconnect Wallet
-            </AnimatedMenuItem>
-          )}
 
           <AnimatedMenuItem icon={LogoutIcon} onClick={handleDisconnect}>
-            Disconnect
+            Logout
           </AnimatedMenuItem>
         </DropdownMenuContent>
       </DropdownMenuPortal>

--- a/src/components/user/user-menu.tsx
+++ b/src/components/user/user-menu.tsx
@@ -116,12 +116,6 @@ export const UserMenu = ({ session, showDropdown = false }: { session: MeResult 
             {session ? "Switch Profile" : "Select Profile"}
           </AnimatedMenuItem>
 
-          {!isWalletConnected && (
-            <AnimatedMenuItem icon={Wallet} onClick={reconnectWallet}>
-              Reconnect Wallet
-            </AnimatedMenuItem>
-          )}
-
           {session && (
             <>
               <AnimatedMenuItem href={`/u/${username}/drafts`} icon={SquarePenIcon}>
@@ -154,6 +148,11 @@ export const UserMenu = ({ session, showDropdown = false }: { session: MeResult 
             </AnimatedMenuItem>
           )}
 
+          {!isWalletConnected && (
+            <AnimatedMenuItem icon={Wallet} onClick={reconnectWallet}>
+              Reconnect Wallet
+            </AnimatedMenuItem>
+          )}
 
           <AnimatedMenuItem icon={LogoutIcon} onClick={handleDisconnect}>
             Logout

--- a/src/components/user/user-menu.tsx
+++ b/src/components/user/user-menu.tsx
@@ -13,6 +13,8 @@ import { useTheme } from "next-themes";
 import { usePathname, useRouter } from "next/navigation";
 import { useAccount, useDisconnect } from "wagmi";
 import { ConnectWalletButton } from "../auth/auth-wallet-button";
+import { Wallet } from "lucide-react";
+import { useReconnectWallet } from "@/hooks/use-reconnect-wallet";
 import { LogoutIcon } from "../icons/logout";
 import { MoonIcon } from "../icons/moon";
 import { SettingsGearIcon } from "../icons/settings";
@@ -59,7 +61,9 @@ export const UserMenu = ({ session, showDropdown = false }: { session: MeResult 
     }
   };
 
-  if (!isWalletConnected && status !== "connecting") {
+  const reconnectWallet = useReconnectWallet();
+
+  if (!session && !isWalletConnected && status !== "connecting") {
     return <ConnectWalletButton text="Login" />;
   }
 
@@ -140,6 +144,12 @@ export const UserMenu = ({ session, showDropdown = false }: { session: MeResult 
               icon={MoonIcon}
             >
               Dark Mode
+            </AnimatedMenuItem>
+          )}
+
+          {!isWalletConnected && (
+            <AnimatedMenuItem icon={Wallet} onClick={reconnectWallet}>
+              Reconnect Wallet
             </AnimatedMenuItem>
           )}
 

--- a/src/hooks/use-reconnect-wallet.ts
+++ b/src/hooks/use-reconnect-wallet.ts
@@ -1,0 +1,7 @@
+"use client";
+import { useModal } from "connectkit";
+
+export const useReconnectWallet = () => {
+  const { setOpen } = useModal();
+  return () => setOpen(true);
+};

--- a/src/hooks/use-save-profile-settings.ts
+++ b/src/hooks/use-save-profile-settings.ts
@@ -9,6 +9,7 @@ import { account } from "@lens-protocol/metadata";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useWalletClient } from "wagmi";
+import { useReconnectWallet } from "./use-reconnect-wallet";
 
 type ProfileSettingsParams = {
   profile: Account;
@@ -22,6 +23,7 @@ type ProfileSettingsParams = {
 export function useSaveProfileSettings() {
   const [isSaving, setIsSaving] = useState(false);
   const { data: walletClient } = useWalletClient();
+  const reconnectWallet = useReconnectWallet();
 
   const saveSettings = async ({ profile, name, bio, picture, coverPicture, attributes }: ProfileSettingsParams) => {
     setIsSaving(true);
@@ -41,6 +43,7 @@ export function useSaveProfileSettings() {
     }
 
     if (!walletClient) {
+      reconnectWallet();
       toast.error("Error: No wallet client found");
       return { success: false, error: "No wallet client found" };
     }


### PR DESCRIPTION
## Summary
- add reconnectWallet hook to more components
- show Reconnect Wallet option in user dropdown when wallet is disconnected
- reconnect wallet in follow button, tip popover, token wrap dialog, onboarding flow, and post menu
- remove unused wallet hooks

## Testing
- `npx @biomejs/biome lint --apply --unsafe src/components/auth/onboarding-modal.tsx src/components/post/post-floating-actions-bar.tsx src/components/post/post-menu.tsx src/components/settings/settings-profile.tsx src/components/tip/tip-popover.tsx src/components/token/token-wrap-dialog.tsx src/components/user/user-follow.tsx src/components/user/user-menu.tsx`
