### PR TITLE
Refactor draft workflow

### DIFF
--- a/src/app/w/collab/[id]/page.tsx
+++ b/src/app/w/collab/[id]/page.tsx
@@ -1,15 +1,17 @@
 import Editor from "@/components/editor/editor";
 import { ArticleLayout } from "@/components/navigation/article-layout";
+import { getAppToken } from "@/lib/auth/get-app-token";
 import { getUserAccount } from "@/lib/auth/get-user-profile";
 import { headers } from "next/headers";
 
-export default async function WriteDraft({ params }: { params: { id: string } }) {
+export default async function CollaborativeDraft({ params }: { params: { id: string } }) {
   const { username } = await getUserAccount();
+  const appToken = getAppToken();
   const pathname = headers().get("x-url") ?? undefined;
 
   return (
     <ArticleLayout>
-      <Editor showToc pathname={pathname} username={username} />
+      <Editor showToc pathname={pathname} username={username} appToken={appToken} />
     </ArticleLayout>
   );
 }

--- a/src/components/editor/addons/editor-autosave.tsx
+++ b/src/components/editor/addons/editor-autosave.tsx
@@ -30,11 +30,11 @@ export function AutoSave({ documentId }: { documentId: string }) {
         const contentMarkdown = api.markdown.serialize({ value: editor.children });
 
         const uniqueImages = [...(existingDraft?.images || [])];
-        images.forEach((img) => {
+        for (const img of images) {
           if (!uniqueImages.includes(img)) {
             uniqueImages.push(img);
           }
-        });
+        }
 
         const draft = {
           ...(existingDraft || {}),
@@ -57,6 +57,13 @@ export function AutoSave({ documentId }: { documentId: string }) {
 
         // FIXME: possibly an issue with the type inference here
         saveDocument(documentId, draft as Draft);
+
+        await fetch(`/api/drafts?id=${documentId}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          credentials: "include",
+          body: JSON.stringify({ content }),
+        });
         setSaveSuccess(true);
         setTimeout(() => {
           setIsVisible(false);


### PR DESCRIPTION
## Summary
- default non-collaborative editor lives at `/w/[id]`
- collaborative drafts served from `/w/collab/[id]`
- convert local drafts to collaborative drafts in share modal
- autosave now persists drafts locally and via `/api/drafts`
- editor fetches draft data when collaboration is disabled

## Testing
- `npx @biomejs/biome format --write src/app/w/[id]/page.tsx src/app/w/collab/[id]/page.tsx src/components/draft/draft-create-button.tsx src/components/draft/draft-share-modal.tsx src/components/editor/addons/editor-autosave.tsx src/components/editor/editor.tsx`
- `npx @biomejs/biome lint --write --unsafe src/app/w/[id]/page.tsx src/app/w/collab/[id]/page.tsx src/components/draft/draft-create-button.tsx src/components/draft/draft-share-modal.tsx src/components/editor/addons/editor-autosave.tsx src/components/editor/editor.tsx`
- `npm run build` *(fails: Failed to fetch Inter font)*