### PR TITLE
Implement collaborative and standalone editor modes

### DIFF
--- a/src/app/api/drafts/route.ts
+++ b/src/app/api/drafts/route.ts
@@ -116,10 +116,6 @@ export async function POST(req: NextRequest) {
       yDoc = `\\x${binaryData.toString("hex")}`;
     }
 
-    if (!yDoc) {
-      return NextResponse.json({ error: "Missing yDoc data" }, { status: 400 });
-    }
-
     const { data, error } = await db
       .from("drafts")
       .insert({

--- a/src/app/w/[id]/page.tsx
+++ b/src/app/w/[id]/page.tsx
@@ -3,15 +3,28 @@ import { ArticleLayout } from "@/components/navigation/article-layout";
 import { getAppToken } from "@/lib/auth/get-app-token";
 import { getUserAccount } from "@/lib/auth/get-user-profile";
 import { headers } from "next/headers";
+import { createClient } from "@/lib/db/server";
 
 export default async function WriteDraft({ params }: { params: { id: string } }) {
   const { username } = await getUserAccount();
-  const appToken = getAppToken();
+  const db = await createClient();
+  const { data } = await db.from("drafts").select("contentJson, yDoc").eq("documentId", params.id).single();
+
+  const isCollaborative = !!data?.yDoc;
+  const appToken = isCollaborative ? getAppToken() : undefined;
   const pathname = headers().get("x-url") ?? undefined;
+  const value = data?.contentJson ? JSON.stringify(data.contentJson) : undefined;
 
   return (
     <ArticleLayout>
-      <Editor showToc pathname={pathname} username={username} appToken={appToken} />
+      <Editor
+        showToc
+        pathname={pathname}
+        username={username}
+        appToken={appToken}
+        value={value}
+        isCollaborative={isCollaborative}
+      />
     </ArticleLayout>
   );
 }

--- a/src/app/w/c/[id]/page.tsx
+++ b/src/app/w/c/[id]/page.tsx
@@ -1,0 +1,17 @@
+import Editor from "@/components/editor/editor";
+import { ArticleLayout } from "@/components/navigation/article-layout";
+import { getAppToken } from "@/lib/auth/get-app-token";
+import { getUserAccount } from "@/lib/auth/get-user-profile";
+import { headers } from "next/headers";
+
+export default async function WriteDraft({ params }: { params: { id: string } }) {
+  const { username } = await getUserAccount();
+  const appToken = getAppToken();
+  const pathname = headers().get("x-url") ?? undefined;
+
+  return (
+    <ArticleLayout>
+      <Editor showToc pathname={pathname} username={username} appToken={appToken} isCollaborative />
+    </ArticleLayout>
+  );
+}

--- a/src/components/draft/draft-share-modal.tsx
+++ b/src/components/draft/draft-share-modal.tsx
@@ -4,26 +4,58 @@ import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { LinkIcon } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { createDraft } from "@/lib/plate/create-draft";
 import { toast } from "sonner";
 import { Badge } from "../ui/badge";
 
 interface DraftShareModalProps {
   isOpen: boolean;
   onClose: () => void;
+  documentId: string;
+  isCollaborative?: boolean;
 }
 
-export const DraftShareModal = ({ isOpen, onClose }: DraftShareModalProps) => {
+export const DraftShareModal = ({ isOpen, onClose, documentId, isCollaborative = false }: DraftShareModalProps) => {
   const [viewAccess, setViewAccess] = useState<"everyone" | "invited">("everyone");
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [isGenerating, setIsGenerating] = useState(false);
+
+  useEffect(() => {
+    if (isCollaborative) {
+      setShareUrl(`${window.location.origin}/w/c/${documentId}`);
+    } else {
+      setShareUrl(null);
+    }
+  }, [isCollaborative, documentId]);
 
   const copyLink = async () => {
+    if (!shareUrl) return;
     try {
-      await navigator.clipboard.writeText(window.location.href);
+      await navigator.clipboard.writeText(shareUrl);
       toast.success("Link copied!", { description: "The draft link has been copied to your clipboard." });
     } catch (_error) {
       toast.error("Failed to copy", {
         description: "There was an error copying the link.",
       });
+    }
+  };
+
+  const enableCollaboration = async () => {
+    setIsGenerating(true);
+    try {
+      const res = await fetch(`/api/drafts?id=${documentId}`);
+      const data = await res.json();
+      const { documentId: newId } = await createDraft({
+        initialContent: data.draft?.contentJson,
+        collaborative: true,
+      });
+      const url = `${window.location.origin}/w/c/${newId}`;
+      setShareUrl(url);
+    } catch (error) {
+      toast.error("Failed to enable collaboration");
+    } finally {
+      setIsGenerating(false);
     }
   };
 
@@ -49,10 +81,16 @@ export const DraftShareModal = ({ isOpen, onClose }: DraftShareModalProps) => {
                 </SelectItem>
               </SelectContent>
             </Select>
-            <Button onClick={copyLink} variant={"ghost"}>
-              <LinkIcon size={18} />
-              {"Copy link"}
-            </Button>
+            {isCollaborative || shareUrl ? (
+              <Button onClick={copyLink} variant={"ghost"} disabled={!shareUrl}>
+                <LinkIcon size={18} />
+                {"Copy link"}
+              </Button>
+            ) : (
+              <Button onClick={enableCollaboration} variant="default" disabled={isGenerating}>
+                {isGenerating ? "Creating..." : "Enable collaboration"}
+              </Button>
+            )}
           </div>
           <p className="text-sm text-muted-foreground">
             {viewAccess === "everyone"

--- a/src/components/editor/addons/editor-autosave.tsx
+++ b/src/components/editor/addons/editor-autosave.tsx
@@ -10,7 +10,13 @@ import { useCallback, useEffect, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import { getStaticEditor, staticComponents } from "../static";
 
-export function AutoSave({ documentId }: { documentId: string }) {
+export function AutoSave({
+  documentId,
+  isCollaborative = false,
+}: {
+  documentId: string;
+  isCollaborative?: boolean;
+}) {
   const editor = useEditorState();
   const { api } = useEditorPlugin(MarkdownPlugin);
   const [isSaving, setIsSaving] = useState(false);
@@ -30,11 +36,11 @@ export function AutoSave({ documentId }: { documentId: string }) {
         const contentMarkdown = api.markdown.serialize({ value: editor.children });
 
         const uniqueImages = [...(existingDraft?.images || [])];
-        images.forEach((img) => {
+        for (const img of images) {
           if (!uniqueImages.includes(img)) {
             uniqueImages.push(img);
           }
-        });
+        }
 
         const draft = {
           ...(existingDraft || {}),
@@ -57,6 +63,14 @@ export function AutoSave({ documentId }: { documentId: string }) {
 
         // FIXME: possibly an issue with the type inference here
         saveDocument(documentId, draft as Draft);
+
+        if (!isCollaborative) {
+          await fetch(`/api/drafts?id=${documentId}`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ content }),
+          });
+        }
         setSaveSuccess(true);
         setTimeout(() => {
           setIsVisible(false);

--- a/src/components/editor/addons/editor-options-dropdown.tsx
+++ b/src/components/editor/addons/editor-options-dropdown.tsx
@@ -9,7 +9,7 @@ import { MenuIcon } from "@/components/icons/menu";
 import { Button } from "@/components/ui/button";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, useOpenState } from "@/components/ui/dropdown-menu";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, usePathname } from "next/navigation";
 import { useState } from "react";
 import { useAuthenticatedUser } from "@lens-protocol/react";
 
@@ -17,6 +17,9 @@ export const EditorOptionsDropdown = () => {
   const { open, onOpenChange } = useOpenState();
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const { data: user } = useAuthenticatedUser();
+  const pathname = usePathname();
+  const documentId = pathname.split("/").pop() ?? "";
+  const isCollaborative = pathname.includes("/w/c/");
 
   const onShare = () => {
     setIsShareModalOpen(true);
@@ -63,7 +66,12 @@ export const EditorOptionsDropdown = () => {
           </AnimatedMenuItem>
         </Link> */}
       </DropdownMenuContent>
-      <DraftShareModal isOpen={isShareModalOpen} onClose={() => setIsShareModalOpen(false)} />
+      <DraftShareModal
+        isOpen={isShareModalOpen}
+        onClose={() => setIsShareModalOpen(false)}
+        documentId={documentId}
+        isCollaborative={isCollaborative}
+      />
     </DropdownMenu>
   );
 };

--- a/src/components/editor/plugins.tsx
+++ b/src/components/editor/plugins.tsx
@@ -96,12 +96,12 @@ const resetBlockTypesCodeBlockRule = {
   onReset: unwrapCodeBlock,
 };
 
-export const getEditorPlugins = (path: string, appToken?: string, isReadOnly?: boolean) => {
+export const getEditorPlugins = (path: string, collaborative: boolean, appToken?: string, isReadOnly?: boolean) => {
   const pluginsList = [...plugins];
 
   const username = appToken ? getTokenClaims(appToken)?.metadata.username : undefined;
 
-  if (appToken) {
+  if (collaborative && appToken) {
     pluginsList.push(
       YjsPlugin.configure({
         render: {
@@ -552,7 +552,7 @@ export const plugins = [
             if (!mdastNode || !mdastNode.children[0]) return;
 
             if (mdastNode.depth === 1) {
-              const text = "value" in mdastNode?.children[0] ? mdastNode.children[0].value : "";
+              const text = "value" in mdastNode.children[0] ? mdastNode.children[0].value : "";
               return {
                 type: TitlePlugin.key,
                 children: [{ text }],
@@ -577,7 +577,7 @@ export const plugins = [
           deserialize: (mdastNode: Heading) => {
             if (!mdastNode || !mdastNode.children[0]) return;
 
-            const text = "value" in mdastNode?.children[0] ? mdastNode.children[0].value : "";
+            const text = "value" in mdastNode.children[0] ? mdastNode.children[0].value : "";
             if (mdastNode.depth === 2) {
               return {
                 type: SubtitlePlugin.key,


### PR DESCRIPTION
## Summary
- add collaborative page route `/w/c/[id]`
- fetch draft data in `/w/[id]` and load Yjs only when collaborative
- support collaborative flag in editor and plugins
- enhance autosave to send updates for standalone drafts
- allow creating drafts without yDoc
- enable collaboration via share modal

## Testing
- `npx @biomejs/biome lint --apply src/app/api/drafts/route.ts src/app/w/[id]/page.tsx src/app/w/c/[id]/page.tsx src/components/draft/draft-share-modal.tsx src/components/editor/addons/editor-autosave.tsx src/components/editor/addons/editor-options-dropdown.tsx src/components/editor/editor.tsx src/components/editor/plugins.tsx src/lib/plate/create-draft.ts`
- `npm run build` *(fails: EHOSTUNREACH for Google Fonts)*