### PR TITLE
Improve email styling

### DIFF
--- a/src/components/email/email-content.ts
+++ b/src/components/email/email-content.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+import { globalThemes, defaultThemeName } from "@/styles/themes";
+
+export interface EmailContentProps {
+  blogName: string;
+  title: string;
+  subtitle?: string;
+  coverUrl?: string;
+  contentHtml: string;
+  postUrl: string;
+}
+
+const articleCssPath = path.join(process.cwd(), "src", "styles", "article.css");
+const articleCss = fs.readFileSync(articleCssPath, "utf8");
+
+function getThemeCss() {
+  const theme = globalThemes[defaultThemeName];
+  const vars = { ...theme.light, ...theme.shared } as Record<string, string>;
+  const cssVars = Object.entries(vars)
+    .map(([k, v]) => `${k}: ${v};`)
+    .join("\n");
+  return `:root{${cssVars}}`;
+}
+
+export function renderEmail({ blogName, title, subtitle, coverUrl, contentHtml, postUrl }: EmailContentProps) {
+  const styles = `${getThemeCss()}\n${articleCss}\nbody{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;line-height:1.6;color:#333;max-width:600px;margin:0 auto;padding:20px;}header{margin-bottom:20px;text-align:center;}footer{margin-top:30px;padding-top:20px;border-top:1px solid #eee;font-size:14px;color:#666;text-align:center;}.button{display:inline-block;background-color:#0070f3;color:#fff;padding:10px 20px;text-decoration:none;border-radius:5px;margin-top:20px;}`;
+  const subtitleHtml = subtitle ? `<h2 class="subtitle">${subtitle}</h2>` : "";
+  const coverHtml = coverUrl ? `<img src="${coverUrl}" alt="cover" class="cover" />` : "";
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><style>${styles}</style></head><body><header><h2>${blogName}</h2></header><article class="article"><h1 class="title">${title}</h1>${subtitleHtml}${coverHtml}<div>${contentHtml}</div><p style="text-align:center"><a href="${postUrl}" class="button">Read the full post</a></p></article><footer><p>You're receiving this email because you subscribed to ${blogName}.</p><p>To unsubscribe, click <a href="{{UnsubscribeURL}}">here</a>.</p></footer></body></html>`;
+}

--- a/src/lib/listmonk/client.ts
+++ b/src/lib/listmonk/client.ts
@@ -2,6 +2,7 @@ import { env } from "@/env";
 import { createClient } from "../db/client";
 import { findBlogByIdentifier } from "../utils/find-blog-by-id";
 import { ListmonkCampaignResponse } from "@/srv/notifications/types";
+import { renderEmail } from "@/components/email/email-content";
 
 export interface ListmonkList {
   id: number;
@@ -388,64 +389,14 @@ export async function createCampaignForPost(
       }
     }
 
-    const campaignBody = `
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>${postTitle}</title>
-        <style>
-          body { 
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 600px;
-            margin: 0 auto;
-            padding: 20px;
-          }
-          h1 { font-size: 24px; margin-bottom: 10px; }
-          h2 { font-size: 20px; margin-bottom: 10px; color: #555; font-weight: normal; }
-          .cover { max-width: 100%; height: auto; margin-bottom: 20px; }
-          .content { margin-bottom: 30px; }
-          .button {
-            display: inline-block;
-            background-color: #0070f3;
-            color: white;
-            padding: 10px 20px;
-            text-decoration: none;
-            border-radius: 5px;
-            margin-top: 20px;
-          }
-          .footer { 
-            margin-top: 30px;
-            padding-top: 20px;
-            border-top: 1px solid #eee;
-            font-size: 14px;
-            color: #666;
-          }
-        </style>
-      </head>
-      <body>
-        <div>
-          <h1>${postTitle}</h1>
-          ${postSubtitle ? `<h2>${postSubtitle}</h2>` : ""}
-          ${coverImageUrl ? `<img src="${coverImageUrl}" alt="Post cover image" class="cover" />` : ""}
-          
-          <div class="content">
-            ${postContent.replace(/\n/g, "<br>")}
-          </div>
-          
-          <a href="${postUrl}" class="button">Read the full post</a>
-          
-          <div class="footer">
-            <p>You're receiving this email because you subscribed to updates from ${blog.display_name || blogId} on Fountain.</p>
-            <p>To unsubscribe from these emails, click <a href="{{UnsubscribeURL}}">here</a>.</p>
-          </div>
-        </div>
-      </body>
-      </html>
-    `;
+    const campaignBody = renderEmail({
+      blogName: blog.display_name || blogId,
+      title: postTitle,
+      subtitle: postSubtitle,
+      coverUrl: coverImageUrl,
+      contentHtml: postContent.replace(/\n/g, "<br>"),
+      postUrl,
+    });
 
     const response = await fetch(`${env.LISTMONK_API_URL}/campaigns`, {
       method: "POST",


### PR DESCRIPTION
## Summary
- add email content generator with article styles
- use styled email when creating Listmonk campaigns

## Testing
- `npx biome format src/components/email/email-content.ts src/lib/listmonk/client.ts --write`
- `npx biome lint src/components/email/email-content.ts src/lib/listmonk/client.ts --apply`
- `npm run build` *(fails: FetchError: request to https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap failed)*