### PR TITLE
Add allowlist fetch for iframe routes

### DIFF
--- a/src/app/api/iframe/route.ts
+++ b/src/app/api/iframe/route.ts
@@ -1,5 +1,8 @@
 import { env } from "@/env";
 import { NextResponse } from "next/server";
+import { JSDOM } from "jsdom";
+
+const allowedDomains = ["dune.com"];
 
 export const revalidate = 60 * 60 * 24 * 2; // 2 days
 
@@ -14,6 +17,33 @@ export async function GET(request: Request) {
   }
 
   try {
+    const { hostname } = new URL(urlToEmbed);
+    const isAllowed = allowedDomains.some((domain) => hostname === domain || hostname.endsWith(`.${domain}`));
+
+    if (isAllowed) {
+      const response = await fetch(urlToEmbed);
+
+      if (!response.ok) {
+        return NextResponse.json(
+          { error: `Failed to fetch iframe: ${response.statusText}` },
+          { status: response.status },
+        );
+      }
+
+      const htmlText = await response.text();
+      const dom = new JSDOM(htmlText);
+      const iframe = dom.window.document.querySelector("iframe");
+
+      if (!iframe) {
+        return NextResponse.json({ error: "No iframe found at URL." }, { status: 400 });
+      }
+
+      const src = iframe.getAttribute("src") ?? urlToEmbed;
+      const wrappedHtml = `<div class="iframely-embed"><div class="iframely-responsive"><iframe src="${src}" allowfullscreen scrolling="no"></iframe></div></div>`;
+
+      return NextResponse.json({ html: wrappedHtml });
+    }
+
     const iframelyApiUrl = `${baseUrl}/iframely?url=${encodeURIComponent(urlToEmbed)}&api_key=${apiKey}&iframe=1&omit_css=1&omit_script=1&theme=auto&lazy=1`;
     const response = await fetch(iframelyApiUrl);
 
@@ -22,7 +52,7 @@ export async function GET(request: Request) {
       console.error("Iframely API error:", response.status, errorData);
       return NextResponse.json(
         { error: `API request failed: ${response.statusText}`, details: errorData },
-        { status: response.status }
+        { status: response.status },
       );
     }
 


### PR DESCRIPTION
## Summary
- allow `dune.com` to bypass Iframely and fetch the iframe HTML directly
- parse the iframe HTML with jsdom and return it wrapped in the iframely markup

## Testing
- `npx @biomejs/biome lint src/app/api/iframe/route.ts --apply --unsafe`
- `npx @biomejs/biome format src/app/api/iframe/route.ts --write`
