### PR TITLE
Enforce !important for custom theme colors

### DIFF
--- a/src/components/blog/blog-theme.tsx
+++ b/src/components/blog/blog-theme.tsx
@@ -5,6 +5,35 @@ import { useEffect, useMemo } from "react";
 import DOMPurify from "dompurify";
 import { useTheme } from "../theme/theme-context";
 
+const COLOR_PROPS = [
+  "color",
+  "background",
+  "background-color",
+  "border-color",
+  "border-top-color",
+  "border-right-color",
+  "border-bottom-color",
+  "border-left-color",
+  "outline-color",
+];
+
+function applyImportantToColors(css: string) {
+  const propertyRegex = /(\s*)([^{}]+{[^}]*})/gms;
+  return css.replace(propertyRegex, (block, leadingWhitespace, rule) => {
+    return (
+      leadingWhitespace +
+      rule.replace(/([^;{}]+):\s*([^;!]+)(;?)/g, (match, prop, value, semicolon) => {
+        const property = prop.trim();
+        const lowerProp = property.toLowerCase();
+        if (value.trim().endsWith("!important") || (!property.startsWith("--") && !COLOR_PROPS.includes(lowerProp))) {
+          return match;
+        }
+        return `${property}: ${value.trim()} !important${semicolon}`;
+      })
+    );
+  });
+}
+
 interface BlogThemeProps {
   children: React.ReactNode;
   initialTheme?: string;
@@ -15,7 +44,8 @@ export const BlogTheme = ({ children, initialTheme, customCss }: BlogThemeProps)
   const { setTheme } = useTheme();
   const sanitizedCustomCss = useMemo(() => {
     console.log("applying custom css: ", customCss);
-    return customCss ? DOMPurify.sanitize(customCss) : "";
+    const sanitized = customCss ? DOMPurify.sanitize(customCss) : "";
+    return sanitized ? applyImportantToColors(sanitized) : "";
   }, [customCss]);
 
   useEffect(() => {

--- a/src/components/blog/blog-theme.tsx
+++ b/src/components/blog/blog-theme.tsx
@@ -22,7 +22,7 @@ function applyImportantToColors(css: string) {
   return css.replace(propertyRegex, (block, leadingWhitespace, rule) => {
     return (
       leadingWhitespace +
-      rule.replace(/([^;{}]+):\s*([^;!]+)(;?)/g, (match, prop, value, semicolon) => {
+      rule.replace(/([^;{}]+):\s*([^;!]+)(;?)/g, (match: any, prop: string, value: string, semicolon: any) => {
         const property = prop.trim();
         const lowerProp = property.toLowerCase();
         if (value.trim().endsWith("!important") || (!property.startsWith("--") && !COLOR_PROPS.includes(lowerProp))) {


### PR DESCRIPTION
## Summary
- automatically append `!important` to color-related declarations in custom CSS

## Testing
- `npx -y @biomejs/biome format --write ./src/components/blog/blog-theme.tsx`
- `npx -y @biomejs/biome lint --write --unsafe ./src/components/blog/blog-theme.tsx`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_683c1135c6d4832e9c4caa8e5dcb87cd