### PR TITLE
Fix newsletter subscriber management bugs

### DIFF
--- a/src/components/blog/blog-newsletter-card.tsx
+++ b/src/components/blog/blog-newsletter-card.tsx
@@ -41,8 +41,10 @@ export function BlogNewsletterCard({ blog }: BlogNewsletterCardProps) {
     };
     
     window.addEventListener("subscriber-deleted", handleSubscriberChange);
+    window.addEventListener("subscriber-added", handleSubscriberChange);
     return () => {
       window.removeEventListener("subscriber-deleted", handleSubscriberChange);
+      window.removeEventListener("subscriber-added", handleSubscriberChange);
     };
   }, [router]);
   const [isLoading, setIsLoading] = useState(false);

--- a/src/components/newsletter/subscriber-data-table.tsx
+++ b/src/components/newsletter/subscriber-data-table.tsx
@@ -361,9 +361,6 @@ export function SubscriberDataTable({ blogAddress, mailListId }: SubscriberDataT
             </Button>
           )}
         </div>
-        <div className="text-sm text-muted-foreground">
-          {table.getSelectedRowModel().rows.length} of {totalCount} row(s) selected.
-        </div>
       </div>
 
       {loading ? (
@@ -461,9 +458,9 @@ export function SubscriberDataTable({ blogAddress, mailListId }: SubscriberDataT
       <AlertDialog open={showBulkDeleteDialog} onOpenChange={setShowBulkDeleteDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Remove {table.getSelectedRowModel().rows.length} subscribers</AlertDialogTitle>
+            <AlertDialogTitle>Remove {table.getSelectedRowModel().rows.length} subscriber{table.getSelectedRowModel().rows.length !== 1 ? 's' : ''}</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to remove {table.getSelectedRowModel().rows.length} selected subscriber(s) from your
+              Are you sure you want to remove {table.getSelectedRowModel().rows.length} selected subscriber{table.getSelectedRowModel().rows.length !== 1 ? 's' : ''} from your
               newsletter? This action cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -476,7 +473,7 @@ export function SubscriberDataTable({ blogAddress, mailListId }: SubscriberDataT
               }}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Remove {table.getSelectedRowModel().rows.length} subscribers
+              Remove {table.getSelectedRowModel().rows.length} subscriber{table.getSelectedRowModel().rows.length !== 1 ? 's' : ''}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -485,9 +482,9 @@ export function SubscriberDataTable({ blogAddress, mailListId }: SubscriberDataT
       <AlertDialog open={showDeleteAllDialog} onOpenChange={setShowDeleteAllDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete ALL {totalCount} subscribers</AlertDialogTitle>
+            <AlertDialogTitle>Delete ALL {totalCount} subscriber{totalCount !== 1 ? 's' : ''}</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to remove ALL {totalCount} subscribers from your newsletter? This will completely
+              Are you sure you want to remove ALL {totalCount} subscriber{totalCount !== 1 ? 's' : ''} from your newsletter? This will completely
               empty your subscriber list and cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
@@ -500,7 +497,7 @@ export function SubscriberDataTable({ blogAddress, mailListId }: SubscriberDataT
               }}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Delete ALL {totalCount} subscribers
+              Delete ALL {totalCount} subscriber{totalCount !== 1 ? 's' : ''}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/newsletter/subscriber-management.tsx
+++ b/src/components/newsletter/subscriber-management.tsx
@@ -17,10 +17,35 @@ interface SubscriberManagementProps {
 export function SubscriberManagement({ blogAddress, mailListId, subscriberCount }: SubscriberManagementProps) {
   const [emails, setEmails] = useState("");
   const [isAdding, setIsAdding] = useState(false);
+  const [validationError, setValidationError] = useState("");
+
+  // Email validation regex
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  const validateEmails = (emailString: string): boolean => {
+    if (!emailString.trim()) {
+      setValidationError("Please enter at least one email address");
+      return false;
+    }
+
+    const emailList = emailString
+      .split(",")
+      .map(email => email.trim())
+      .filter(email => email.length > 0);
+
+    const invalidEmails = emailList.filter(email => !emailRegex.test(email));
+    
+    if (invalidEmails.length > 0) {
+      setValidationError(`Invalid email format: ${invalidEmails.join(", ")}`);
+      return false;
+    }
+
+    setValidationError("");
+    return true;
+  };
 
   const handleAddEmails = async () => {
-    if (!emails.trim()) {
-      toast.error("Please enter at least one email address");
+    if (!validateEmails(emails)) {
       return;
     }
 
@@ -79,7 +104,18 @@ export function SubscriberManagement({ blogAddress, mailListId, subscriberCount 
             type="text"
             placeholder="Enter email addresses, comma separated"
             value={emails}
-            onChange={(e) => setEmails(e.target.value)}
+            onChange={(e) => {
+              setEmails(e.target.value);
+              if (validationError) {
+                validateEmails(e.target.value);
+              }
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !isAdding && emails.trim()) {
+                e.preventDefault();
+                handleAddEmails();
+              }
+            }}
             className="flex-1"
             disabled={isAdding}
             autoComplete="off"
@@ -93,6 +129,9 @@ export function SubscriberManagement({ blogAddress, mailListId, subscriberCount 
             Add emails
           </Button>
         </div>
+        {validationError && (
+          <p className="text-sm text-destructive">{validationError}</p>
+        )}
       </div>
 
       {/* Subscribers Table */}


### PR DESCRIPTION
## Summary
- Fixed multiple bugs in the newsletter subscriber management interface
- Improved user experience with proper validation and keyboard support

## Changes
- **F-641**: Removed redundant "0 of x rows selected" text since the delete button already shows the count
- **F-639**: Added email validation with regex to ensure only valid email formats are accepted
- **F-638**: Added Enter key support to submit the email form for better UX
- **F-637**: Fixed subscriber count not updating after manual additions by listening to "subscriber-added" events
- **F-644**: Fixed pluralization in delete confirmation modals (shows "1 subscriber" vs "2 subscribers")

## Test plan
- [ ] Verify selection counter text is removed from the subscriber table
- [ ] Test adding invalid email formats (should show validation error)
- [ ] Test adding valid emails with Enter key (should submit)
- [ ] Add subscribers manually and verify the count updates in the header
- [ ] Test delete modals with 1 subscriber (should show singular)
- [ ] Test delete modals with multiple subscribers (should show plural)

🤖 Generated with [Claude Code](https://claude.ai/code)